### PR TITLE
fix: `validate-tag-with-version`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
           name: Check if git tag name is appropriate for package version
           command: |
             tag=$CIRCLE_TAG
-            version=$(poetry run python -c 'from importlib.metadata import Distribution; print(Distribution.from_name("pyproject-indirect-import-detector").version)')
+            version=$(poetry run python -c 'import toml; print(toml.load("pyproject.toml")["tool"]["poetry"]["version"])')
             test "$tag" = "$version"
   deploy:
     docker:


### PR DESCRIPTION
fix: https://app.circleci.com/pipelines/github/kenoss/pyproject-indirect-import-detector/28/workflows/dbbbd03c-a365-4bd1-aab9-ed7234a6b663/jobs/103