### PR TITLE
Bump version 0.1.0a1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyproject-indirect-import-detector"
-version = "0.1.0a0"
+version = "0.1.0a1"
 description = "CI tool to detect indirect import"
 authors = ["keno <keno.ss57@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Tested with [nitpick](https://github.com/andreoliwa/nitpick) and [isort](https://github.com/PyCQA/isort). Ready for 0.1.0 release.